### PR TITLE
SCANNERAPI-201 Migrate away of GCP promote function

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -98,8 +98,7 @@ promote_task:
     memory: 500M
   env:
     GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
-    GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
-    PROMOTE_URL: VAULT[development/kv/data/promote data.url]
+    ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
   maven_cache:
     folder: $CIRRUS_WORKING_DIR/.m2/repository
   script:


### PR DESCRIPTION
[Context](https://sonarsource.atlassian.net/browse/BUILD-3956?focusedCommentId=542698)
[Documentation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/RE/pages/2931064959/Cirrus+CI+-+How+to+migrate+away+of+GCP+promote+function)

Ticket: https://sonarsource.atlassian.net/browse/SCANNERAPI-201