### PR TITLE
SCANNERAPI-203 Fix flaky simple analysis with server certificate test

### DIFF
--- a/its/it-tests/pom.xml
+++ b/its/it-tests/pom.xml
@@ -26,8 +26,8 @@
 
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
-      <artifactId>sonar-orchestrator</artifactId>
-      <version>3.40.0.183</version>
+      <artifactId>sonar-orchestrator-junit4</artifactId>
+      <version>4.5.0.1700</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/its/it-tests/src/test/java/com/sonar/scanner/api/it/PropertiesTest.java
+++ b/its/it-tests/src/test/java/com/sonar/scanner/api/it/PropertiesTest.java
@@ -19,8 +19,8 @@
  */
 package com.sonar.scanner.api.it;
 
-import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
+import com.sonar.orchestrator.junit4.OrchestratorRule;
 import com.sonar.scanner.api.it.tools.SimpleScanner;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class PropertiesTest {
   @ClassRule
-  public static final Orchestrator ORCHESTRATOR = ScannerCommonsTestSuite.ORCHESTRATOR;
+  public static final OrchestratorRule ORCHESTRATOR = ScannerCommonsTestSuite.ORCHESTRATOR;
 
   @Test
   public void testRuntimeEnvironmentPassedAsUserAgent() throws IOException {

--- a/its/it-tests/src/test/java/com/sonar/scanner/api/it/ProxyTest.java
+++ b/its/it-tests/src/test/java/com/sonar/scanner/api/it/ProxyTest.java
@@ -19,8 +19,8 @@
  */
 package com.sonar.scanner.api.it;
 
-import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
+import com.sonar.orchestrator.junit4.OrchestratorRule;
 import com.sonar.orchestrator.util.NetworkUtils;
 import com.sonar.scanner.api.it.tools.ProxyAuthenticator;
 import com.sonar.scanner.api.it.tools.SimpleScanner;
@@ -68,7 +68,7 @@ public class ProxyTest {
   private static int httpProxyPort;
 
   @ClassRule
-  public static final Orchestrator ORCHESTRATOR = ScannerCommonsTestSuite.ORCHESTRATOR;
+  public static final OrchestratorRule ORCHESTRATOR = ScannerCommonsTestSuite.ORCHESTRATOR;
 
   private static ConcurrentLinkedDeque<String> seenByProxy = new ConcurrentLinkedDeque<>();
 

--- a/its/it-tests/src/test/java/com/sonar/scanner/api/it/SSLTest.java
+++ b/its/it-tests/src/test/java/com/sonar/scanner/api/it/SSLTest.java
@@ -19,8 +19,8 @@
  */
 package com.sonar.scanner.api.it;
 
-import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
+import com.sonar.orchestrator.junit4.OrchestratorRule;
 import com.sonar.orchestrator.util.NetworkUtils;
 import com.sonar.scanner.api.it.tools.SimpleScanner;
 import java.net.InetAddress;
@@ -73,7 +73,7 @@ public class SSLTest {
   private static int httpsPort;
 
   @ClassRule
-  public static final Orchestrator ORCHESTRATOR = ScannerCommonsTestSuite.ORCHESTRATOR;
+  public static final OrchestratorRule ORCHESTRATOR = ScannerCommonsTestSuite.ORCHESTRATOR;
 
   @Before
   public void deleteData() {

--- a/its/it-tests/src/test/java/com/sonar/scanner/api/it/ScannerCommonsTestSuite.java
+++ b/its/it-tests/src/test/java/com/sonar/scanner/api/it/ScannerCommonsTestSuite.java
@@ -19,8 +19,8 @@
  */
 package com.sonar.scanner.api.it;
 
-import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.http.HttpMethod;
+import com.sonar.orchestrator.junit4.OrchestratorRule;
 import com.sonar.orchestrator.locator.MavenLocation;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -39,7 +39,7 @@ public class ScannerCommonsTestSuite {
   private static final String SONAR_RUNTIME_VERSION = "sonar.runtimeVersion";
 
   @ClassRule
-  public static final Orchestrator ORCHESTRATOR = Orchestrator.builderEnv()
+  public static final OrchestratorRule ORCHESTRATOR = OrchestratorRule.builderEnv()
     .setSonarVersion(getSystemPropertyOrFail(SONAR_RUNTIME_VERSION))
     .useDefaultAdminCredentialsForBuilds(true)
     // We need to use a plugin compatible with both SonarQube DEV & SonarQube version defined in .cirrus.yml (currently SQ 7.9)
@@ -54,7 +54,7 @@ public class ScannerCommonsTestSuite {
     return propertyValue;
   }
 
-  public static void resetData(Orchestrator orchestrator) {
+  public static void resetData(OrchestratorRule orchestrator) {
     Instant instant = Instant.now();
 
     // The expected format is yyyy-MM-dd.


### PR DESCRIPTION
Upgrading to the latest orchestrator seems to have solved this issue of random ports being signed to one that is by chance already being used.